### PR TITLE
#1 Global “magical” surfaces (window.sessions, window.dm, window.omni)

### DIFF
--- a/renderer/installer.html
+++ b/renderer/installer.html
@@ -80,22 +80,22 @@
     var btnOpen = document.getElementById('btnOpenLogs');
     var btnGo   = document.getElementById('btnProceed');
 
-    if (!window.bootstrap) { console.error('preload missing'); return; }
+    if (!window.api || !window.api.bootstrap) { console.error('preload/api missing'); return; }
     var logEl   = document.getElementById('log');
     function appendLog(s){ if(!logEl) return; logEl.textContent += String(s); logEl.scrollTop = logEl.scrollHeight; }
 
     // subscribe to background-mode logs (mac auto-tail + background run)
-    var offLog = window.bootstrap.onLog(function(line){ appendLog(line); });
-    var offDone = window.bootstrap.onDone(function(){ statusEl.textContent = 'ok'; statusEl.classList.add('ok'); });
-    var offErr  = window.bootstrap.onError(function(code){ statusEl.textContent = 'error'; statusEl.classList.add('err'); appendLog('\\n[bootstrap] exited with code '+code+'\\n'); });
+    var offLog = window.api.bootstrap.onLog(function(line){ appendLog(line); });
+    var offDone = window.api.bootstrap.onDone(function(){ statusEl.textContent = 'ok'; statusEl.classList.add('ok'); });
+    var offErr  = window.api.bootstrap.onError(function(code){ statusEl.textContent = 'error'; statusEl.classList.add('err'); appendLog('\n[bootstrap] exited with code '+code+'\n'); });
 
     btnRun.addEventListener('click', function () {
       statusEl.textContent = 'Installing…';
       statusEl.classList.remove('ok','err');
-      window.bootstrap.runInTerminal();
+      window.api.bootstrap.runInTerminal();
     });
-    btnOpen.addEventListener('click', function () { window.bootstrap.openLogsDir(); });
-    btnGo.addEventListener('click', function () { window.bootstrap.proceedIfReady(); });
+    btnOpen.addEventListener('click', function () { window.api.bootstrap.openLogsDir(); });
+    btnGo.addEventListener('click', function () { window.api.bootstrap.proceedIfReady(); });
   })();
   </script>
 

--- a/renderer/lib/adapter.js
+++ b/renderer/lib/adapter.js
@@ -1,0 +1,40 @@
+class Bus {
+  constructor() { this._m = new Map(); }
+  on(topic, fn) {
+    const t = String(topic);
+    const arr = this._m.get(t) || [];
+    arr.push(fn);
+    this._m.set(t, arr);
+    return () => this.off(t, fn);
+  }
+  off(topic, fn) {
+    const t = String(topic);
+    const arr = this._m.get(t);
+    if (!arr) return;
+    const i = arr.indexOf(fn);
+    if (i >= 0) arr.splice(i, 1);
+    if (arr.length === 0) this._m.delete(t);
+  }
+  emit(topic, payload) {
+    const arr = this._m.get(String(topic));
+    if (!arr) return;
+    for (const fn of arr.slice()) { try { fn(payload); } catch {} }
+  }
+}
+
+// Use the injected API from preload; fall back to a no-op in dev
+const injected = globalThis.window?.api;
+if (!injected) {
+  console.warn('[adapter] window.api not injected; using inert shim for dev.');
+}
+
+const inert = {
+  events: new Bus(),
+  sessions: { start: async()=>{}, stop:()=>{}, send:()=>{}, onStatus:()=>{}, onError:()=>{}, onData:()=>{} },
+  dm: { open: async()=>{}, notify:()=>{}, requestUser:()=>{}, pushUser:()=>{} },
+  settings: { getAll: async()=>({}), set: async()=>{} },
+  profiles: { list: async()=>({}), resolve: async(h)=>({ host:h }), upsert: async()=>{}, del: async()=>{} },
+  bootstrap: { runInTerminal:()=>{}, openLogsDir:()=>{}, proceedIfReady:()=>{}, onLog:()=>()=>{}, onDone:()=>()=>{}, onError:()=>()=>{} },
+};
+
+export const api = injected || inert;

--- a/renderer/ui/ChannelListPane.js
+++ b/renderer/ui/ChannelListPane.js
@@ -1,3 +1,5 @@
+import { api } from '../lib/adapter.js';
+
 export class ChannelListPane {
   constructor(net) {
     this.net = net;
@@ -63,7 +65,7 @@ export class ChannelListPane {
     this.refreshBtn.addEventListener('click', () => this.requestList());
 
     // subscribe to chanlist snapshots (already published by ingest)
-    window.omni.onUI('chanlist', (payload) => {
+    api.events.on('ui:chanlist', (payload) => {
       if (!payload || payload.sessionId !== this.net.sessionId) return;
       this.items = Array.isArray(payload.items) ? payload.items : [];
       this.render();
@@ -84,7 +86,7 @@ export class ChannelListPane {
   requestList() {
     if (!this.net?.sessionId) return;
     this.setLoading(true);
-    window.sessions.send(this.net.sessionId, '/list * 30');
+    api.sessions.send(this.net.sessionId, '/list * 30');
   }
 
   setLoading(on) {
@@ -118,7 +120,7 @@ export class ChannelListPane {
       btn.addEventListener('click', () => {
         if (!this.net?.sessionId) return;
         const chan = name.startsWith('#') || name.startsWith('&') ? name : `#${name}`;
-        window.sessions.send(this.net.sessionId, `/join ${chan}`);
+        api.sessions.send(this.net.sessionId, `/join ${chan}`);
       });
       tdName.appendChild(btn);
 

--- a/renderer/ui/ChannelPane.js
+++ b/renderer/ui/ChannelPane.js
@@ -1,3 +1,4 @@
+import { api } from '../lib/adapter.js';
 import { TranscriptBuffer } from './TranscriptBuffer.js';
 
 export class ChannelPane {
@@ -78,7 +79,7 @@ export class ChannelPane {
       chip.textContent = nick;
       chip.title = `Open DM with ${nick}`;
       chip.addEventListener('click', () => {
-        window.dm.open(this.net.sessionId, nick, null);
+        api.dm.open(this.net.sessionId, nick, null);
       });
 
       chip.addEventListener('mouseenter', () => this._scheduleWhois(nick));
@@ -97,7 +98,7 @@ export class ChannelPane {
     const text = this.msgInput.value.trim();
     if (!text) return;
     if (this.net?.sessionId) {
-      window.sessions.send(this.net.sessionId, `/msg ${this.name} ${text}`);
+      api.sessions.send(this.net.sessionId, `/msg ${this.name} ${text}`);
       this.appendLine(`> ${text}`);
       this.msgInput.value = '';
     }
@@ -110,7 +111,7 @@ export class ChannelPane {
     const t = setTimeout(() => {
       this._whoisHoverTimers.delete(nick);
       if (this.net?.sessionId) {
-        window.sessions.send(this.net.sessionId, `/whois ${nick} ${nick}`);
+        api.sessions.send(this.net.sessionId, `/whois ${nick} ${nick}`);
       }
     }, 220); // small debounce so casual passes don’t fire
     this._whoisHoverTimers.set(nick, t);

--- a/renderer/ui/ConsolePane.js
+++ b/renderer/ui/ConsolePane.js
@@ -1,3 +1,4 @@
+import { api } from '../lib/adapter.js';
 import { TranscriptBuffer } from './TranscriptBuffer.js';
 
 export class ConsolePane {
@@ -50,7 +51,7 @@ export class ConsolePane {
     const text = this.msgInput.value.trim();
     if (!text) return;
     if (this.net?.sessionId) {
-      window.sessions.send(this.net.sessionId, text);
+      api.sessions.send(this.net.sessionId, text);
       this.appendLine(`> ${text}`);
       this.msgInput.value = '';
     }

--- a/renderer/ui/PrivmsgPane.js
+++ b/renderer/ui/PrivmsgPane.js
@@ -1,3 +1,4 @@
+import { api } from '../lib/adapter.js';
 export class PrivmsgPane {
   constructor(net, peerNick, onClose) {
     this.net = net;
@@ -58,7 +59,7 @@ export class PrivmsgPane {
       const text = this.input.value.trim();
       if (!text) return;
       if (this.net?.sessionId) {
-        window.sessions.send(this.net.sessionId, `/msg ${this.peer} ${text}`);
+        api.sessions.send(this.net.sessionId, `/msg ${this.peer} ${text}`);
         this.appendLine(`> ${text}`);
         this.input.value = '';
       }


### PR DESCRIPTION
Closes #1

## Why

**Smell:** views reached into multiple global namespaces (`window.sessions`, `window.dm`, `window.omni`) with ad-hoc methods/events and optional chaining everywhere.
**Hurt:** hard to trace data flow, painful to mock/test, silent contract drift (missing handlers ignored).
**Direction:** establish a *single* injected **Renderer API** adapter + central event bus; views depend on one interface, not globals.

## What changed (high level)

* Added `renderer/lib/adapter.js` that exposes a single `api` object to views.
* Reworked `preload.cjs` to:

  * implement a small in-process event bus,
  * forward main-process IPC channels onto named topics,
  * expose `window.api` with typed groups: `events`, `sessions`, `dm`, `settings`, `profiles`, `bootstrap`.
* Updated all renderer views/components to use `api.*` instead of touching `window.sessions`, `window.dm`, or `window.omni`.
* Centralized DM lifecycle + WHOIS/user fan-out through the new bus.
* Normalized channel list and ingest handling to publish snapshots via `api.events`.

## Files touched

**Modified**

* `preload.cjs`
* `renderer/dm.js`
* `renderer/installer.html`
* `renderer/irc/ingest.js`
* `renderer/main.js`
* `renderer/ui/ChannelListPane.js`
* `renderer/ui/ChannelPane.js`
* `renderer/ui/ConsolePane.js`
* `renderer/ui/PrivmsgPane.js`
* `renderer/ui/connectionForm.js`

**Added**

* `renderer/lib/adapter.js` (unified adapter & inert dev shim)

## New public surface (renderer)

```ts
window.api = {
  events: { on(topic, fn), off(topic, fn), emit(topic, payload) },

  sessions: {
    start(id, opts), stop(id), restart(id, opts?),
    send(id, line),
    onStatus(fn), onError(fn), onData(fn),
  },

  dm: {
    open(sessionId, peer, bootLine?),
    notify(sessionId, peer),
    requestUser(sessionId, nick),
    // pushUser is main→renderer only
  },

  settings: { getAll(), set(key, value) },
  profiles: { list(), resolve(host), upsert(host, payload), del(host) },

  bootstrap: {
    runInTerminal(), startInBackground(), openLogsDir(), proceedIfReady(),
    onLog(fn), onDone(fn), onError(fn),
  },
};
```

## Before/After (usage)

**Before**

```js
// many views
window.sessions.send(id, line);
window.dm.open(sessionId, nick, bootLine);
window.omni.getAllSettings();
```

**After**

```js
import { api } from '../lib/adapter.js';

api.sessions.send(id, line);
api.dm.open(sessionId, nick, bootLine);
const settings = await api.settings.getAll();
api.events.on('dm:play-sound', handler);
```

## Key implementation notes

* **Event bus:** lightweight pub/sub in `preload.cjs`. Main’s IPC (`session:*`, `dm:*`, `bootstrap:*`) is forwarded onto bus topics that views subscribe to via `api.events.on(...)`.
* **Inert dev shim:** `adapter.js` falls back to a no-op `api` when `window.api` isn’t injected, easing renderer-only dev and storybook-style previews.
* **DM/WHOIS stability:**

  * DM windows receive `dm:init`, `dm:line`, `dm:user` via bus.
  * Renderer can `api.dm.requestUser(...)` to hydrate headers immediately.
  * Notification sound uses the `dm:play-sound` topic.
  * NickServ messages are swallowed (no DM window) and **auto-identify** is issued once per session if configured.
* **Channel list:** snapshots are published on `ui:chanlist`; the pane subscribes and renders sorted by user count.
* **Security posture unchanged:** `contextIsolation: true`, `nodeIntegration: false` remain.

## Breaking changes

* **Removed/Deprecated renderer globals**

  * `window.sessions` → use `api.sessions.*`
  * `window.dm` → use `api.dm.*` and `api.events.on('dm:*', …)`
  * `window.omni` → use `api.settings.*` and `api.profiles.*`
* Any direct `ipcRenderer.on(...)` in views is replaced with `api.events.on(...)`.

### Migration guide (search/replace hints)

* `window.sessions.` → `api.sessions.`
* `window.dm.` → `api.dm.` and bus topics `dm:*` via `api.events.on(...)`
* `window.omni.getAllSettings()` → `api.settings.getAll()`
* `window.omni.setSetting(k,v)` → `api.settings.set(k,v)`
* `window.omni.profilesXxx` → `api.profiles.xxx`
* Direct `ipcRenderer` usage in renderer code → subscribe with `api.events.on(topic, handler)`

## Testing performed

* **Session lifecycle:** start → `sessions:status` “running” and streaming `sessions:data`; stop/restart cleanly.
* **Channels:** join, send/receive; LIST numerics (321–323) suppressed in transcript.
* **DMs:**

  * Inbound DM opens/focuses window; sound cue; Windows overlay badge, macOS dock badge.
  * WHOIS/user data appears in DM header; nick changes propagate to cache and window.
  * NickServ notices **do not** open DM; single auto-identify when configured.
* **Installer:** bootstrap logs stream; “Check & Continue” uses `bootstrap:proceed-if-ready`.

## Risks & mitigations

* **API drift** between main and preload → all routing consolidated in `preload.cjs`; unknown/missing topics localized to a single place.
* **Renderer dev without Electron** → inert adapter prevents crashes; methods no-op by design.
* **Silent failures** → fewer: event/topic names are centralized; fewer ad-hoc channels.

## How to review

1. Skim `preload.cjs` for the bus + API surface.
2. Verify `renderer/lib/adapter.js` inert fallback.
3. Spot-check a few views (`dm.js`, `ChannelListPane.js`) for `api.*` usage.
4. Manual QA across platforms (sound & badges):

   * Windows: overlay icon appears on DM; clears on focus.
   * macOS: dock badge appears; clears on focus.
   * Linux: no overlay, but DM still opens and plays sound.

## Follow-ups (nice to have)

* Extract event/topic strings to a shared constants module.
* Add runtime payload validation at the `preload.cjs` boundary (e.g., zod).
* Add smoke tests: session start/stop, DM notify path, chanlist snapshot.
* Docs: quick “Renderer API” section in README.

---

**Ticket:** Global “magical” surfaces (`window.sessions`, `window.dm`, `window.omni`) #1
**Motivation:** reduce coupling, make dataflow explicit, improve testability and evolvability.
