### PR TITLE
#2 Canonicalize Eventing, Fix DM Double-Ding

### DIFF
--- a/renderer/lib/adapter.js
+++ b/renderer/lib/adapter.js
@@ -22,6 +22,33 @@ class Bus {
   }
 }
 
+/** Canonical topics (single source of truth for event names). */
+export const TOPICS = Object.freeze({
+  CONN_STATUS:   'conn:status',
+  CONN_ERROR:    'conn:error',
+  CONN_LINE:     'conn:line',
+  CHAN_SNAPSHOT: 'chan:snapshot',
+  CHAN_UPDATE:   'chan:update',
+  DM_LINE:       'dm:line',
+  DM_USER:       'dm:user',
+  DM_NOTIFY:     'dm:notify',
+  UI_ACTIVE:     'ui:active-session',
+  ERROR:         'error',
+});
+
+/**
+ * @typedef {{sessionId:string,status:"starting"|"online"|"offline"|"error"}} ConnStatus
+ * @typedef {{sessionId:string,message:string}} ConnError
+ * @typedef {{sessionId:string,line:string}} ConnLine
+ * @typedef {{sessionId:string,items:{name:string,users:number,topic:string}[]}} ChanSnapshot
+ * @typedef {{sessionId:string,channel:{name:string,topic?:string,users?:string[]}}} ChanUpdate
+ * @typedef {{sessionId:string,from:string,to:string,kind:"PRIVMSG"|"NOTICE",text:string}} DMLine
+ * @typedef {{sessionId:string,user:Object}} DMUser
+ * @typedef {{sessionId:string,peer:string}} DMNotify
+ * @typedef {{id:string}} UIActive
+ * @typedef {{scope:string,message:string}} UIError
+ */
+
 // Use the injected API from preload; fall back to a no-op in dev
 const injected = globalThis.window?.api;
 if (!injected) {
@@ -38,3 +65,5 @@ const inert = {
 };
 
 export const api = injected || inert;
+export const events = (injected || inert).events;
+export { TOPICS as EVT };

--- a/renderer/ui/ChannelListPane.js
+++ b/renderer/ui/ChannelListPane.js
@@ -1,4 +1,4 @@
-import { api } from '../lib/adapter.js';
+import { api, events, EVT } from '../lib/adapter.js';
 
 export class ChannelListPane {
   constructor(net) {
@@ -64,8 +64,8 @@ export class ChannelListPane {
     // events
     this.refreshBtn.addEventListener('click', () => this.requestList());
 
-    // subscribe to chanlist snapshots (already published by ingest)
-    api.events.on('ui:chanlist', (payload) => {
+    // subscribe to canonical chan snapshots
+    events.on(EVT.CHAN_SNAPSHOT, (payload) => {
       if (!payload || payload.sessionId !== this.net.sessionId) return;
       this.items = Array.isArray(payload.items) ? payload.items : [];
       this.render();


### PR DESCRIPTION
### Problem(s)
- **Inconsistent eventing**: ad-hoc/legacy event strings (`sessions:*`, `ui:chanlist`, `dm:play-sound`) scattered across layers.
- **Double audio** when a DM arrives at the same time a DM window opens.
- **Regression**: After the refactor, **no notification** when a new **PRIVMSG** comes in for a DM window that’s **open but minimized/unfocused**.

### Goals
- Introduce **canonical event topics** and route everything through a single, local **Bus**.
- **Eliminate duplicate ding** on DM open.
- **Restore notifications** when DM is open but **not visible**.

---

## Summary of Changes

### Canonical topics (`EVT`)
Added to `renderer/lib/adapter.js` and mirrored in `preload.cjs`:

- `CONN_STATUS`, `CONN_ERROR`, `CONN_LINE`
- `CHAN_SNAPSHOT`, `CHAN_UPDATE`
- `DM_USER`, `DM_LINE`, `DM_NOTIFY`
- `UI_ACTIVE`, `ERROR`

All renderer code now **imports `{ events, EVT }`** and **subscribes/emits only canonical topics**.

### Preload bridge (`preload.cjs`)
- Bridges Electron IPC → **canonical** Bus events.
- **Keeps legacy emissions** (e.g., `sessions:*`, `dm:*`) for **back-compat**.
- Converts `dm:init` into a richer fan-out:
  - Emits a stub `DM_USER` (so DM header renders immediately),
  - Emits boot `DM_LINE`s,
  - Emits a `DM_NOTIFY` nudge.
- Maps legacy `dm:play-sound` → `DM_NOTIFY`.

### DM behavior (`renderer/dm.js`)
- Plays sound **only** when receiving `EVT.DM_NOTIFY` **for this** `(sessionId, peer)`.
- Tracks visibility via:
  ```js
  let isFocused = document.hasFocus();
  window.addEventListener('focus', () => { isFocused = true; });
  window.addEventListener('blur',  () => { isFocused = false; });