### PR TITLE
Remove stringly/innerHTML rendering, safe DOM helpers, simplify DM user handling #4

### DIFF
--- a/renderer/lib/dom.js
+++ b/renderer/lib/dom.js
@@ -1,0 +1,29 @@
+// Minimal DOM helpers to keep us honest about tainted strings.
+// Use textContent by default; only use esc() with innerHTML in rare, controlled cases.
+export function esc(s) {
+  return String(s).replace(/[&<>"']/g, c => (
+    ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])
+  ));
+}
+
+export function el(tag, props = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(props)) {
+    if (k === 'className') node.className = v;
+    else if (k === 'text') node.textContent = v;
+    else if (k === 'html') node.innerHTML = v; // Use only with already-sanitized strings.
+    else if (k.startsWith('on') && typeof v === 'function') node.addEventListener(k.slice(2), v);
+    else node.setAttribute(k, v);
+  }
+  for (const ch of (Array.isArray(children) ? children : [children])) {
+    if (ch == null) continue;
+    node.appendChild(typeof ch === 'string' ? document.createTextNode(ch) : ch);
+  }
+  return node;
+}
+
+// Tainted inputs checklist (reference):
+// - nick, user, host, realname/account
+// - server/host labels, channel names, topics
+// - message text, DM peer, tab titles
+// Never feed these into innerHTML. Prefer textContent or the el() builder.

--- a/renderer/main.js
+++ b/renderer/main.js
@@ -3,6 +3,7 @@ import { setupIngest } from './irc/ingest.js';
 import { ErrorDock } from './ui/ErrorDock.js';
 import { createProfilesPanel } from './ui/connectionForm.js';
 import { api, events, EVT } from './lib/adapter.js';
+import { el } from './lib/dom.js';
 
 uiRefs.viewsEl      = document.getElementById('views');
 uiRefs.errorDockEl  = document.getElementById('errorDock');
@@ -17,25 +18,23 @@ let activeSessionId = null;
 const tabs = new Map(); // id -> { id, title, layerEl, netId? }
 
 function renderTabs() {
-  tabbarEl.innerHTML = '';
+  tabbarEl.textContent = '';
   for (const { id, title } of tabs.values()) {
-    const el = document.createElement('div');
-    el.className = 'tab' + (id === activeSessionId ? ' active' : '');
-    el.innerHTML = `<span class="title">${title}</span><span class="close" title="Close">x</span>`;
-    el.addEventListener('click', (ev) => {
-      if (ev.target.closest('.close')) {
+    const tab = el('div', { className: 'tab' + (id === activeSessionId ? ' active' : '') });
+    const titleSpan = el('span', { className: 'title', text: String(title ?? '') });
+    const closeSpan = el('span', { className: 'close', title: 'Close', text: 'x' });
+    tab.append(titleSpan, closeSpan);
+    tab.addEventListener('click', (ev) => {
+      if (ev.target === closeSpan) {
         closeTab(id);
         ev.stopPropagation();
         return;
       }
       activateTab(id);
     });
-    tabbarEl.appendChild(el);
+    tabbarEl.appendChild(tab);
   }
-  const plus = document.createElement('button');
-  plus.id = 'newTabBtn';
-  plus.textContent = '+';
-  plus.title = 'Open new connection tab';
+  const plus = el('button', { id: 'newTabBtn', title: 'Open new connection tab', text: '+' });
   plus.addEventListener('click', openNewTab);
   tabbarEl.appendChild(plus);
 }

--- a/renderer/ui/ChannelListPane.js
+++ b/renderer/ui/ChannelListPane.js
@@ -36,21 +36,31 @@ export class ChannelListPane {
     this.loading = document.createElement('div');
     this.loading.className = 'chanlist-loading';
     this.loading.setAttribute('hidden', 'true');
-    this.loading.innerHTML = `<div class="spinner" role="status" aria-label="Loading"></div>`;
+    const spinner = document.createElement('div');
+    spinner.className = 'spinner';
+    spinner.setAttribute('role', 'status');
+    spinner.setAttribute('aria-label', 'Loading');
+    this.loading.appendChild(spinner);
     this.wrap.appendChild(this.loading);
 
     // table
     this.table = document.createElement('table');
     this.table.setAttribute('aria-label', 'Channel List');
-    this.table.innerHTML = `
-      <thead>
-        <tr>
-          <th class="num" style="width:12%;">Users</th>
-          <th style="width:28%;">Channel</th>
-          <th>Topic</th>
-        </tr>
-      </thead>
-      <tbody></tbody>`;
+    const thead = document.createElement('thead');
+    const tr = document.createElement('tr');
+    const thUsers = document.createElement('th');
+    thUsers.className = 'num';
+    thUsers.style.width = '12%';
+    thUsers.textContent = 'Users';
+    const thChan = document.createElement('th');
+    thChan.style.width = '28%';
+    thChan.textContent = 'Channel';
+    const thTopic = document.createElement('th');
+    thTopic.textContent = 'Topic';
+    tr.append(thUsers, thChan, thTopic);
+    thead.appendChild(tr);
+    this.tbody = document.createElement('tbody');
+    this.table.append(thead, this.tbody);
     this.tbody = this.table.querySelector('tbody');
     this.wrap.appendChild(this.table);
 

--- a/renderer/ui/ChannelPane.js
+++ b/renderer/ui/ChannelPane.js
@@ -29,7 +29,11 @@ export class ChannelPane {
 
     this.usersEl = document.createElement('div');
     this.usersEl.className = 'users';
-    this.usersEl.innerHTML = `<h4>Users</h4><div class="user-list"></div>`;
+    const usersH4 = document.createElement('h4');
+    usersH4.textContent = 'Users';
+    this.userListEl = document.createElement('div');
+    this.userListEl.className = 'user-list';
+    this.usersEl.append(usersH4, this.userListEl);
     this.userListEl = this.usersEl.querySelector('.user-list');
 
     this.inputRow = document.createElement('div');

--- a/renderer/ui/PrivmsgPane.js
+++ b/renderer/ui/PrivmsgPane.js
@@ -1,4 +1,6 @@
 import { api } from '../lib/adapter.js';
+import { el } from '../lib/dom.js';
+
 export class PrivmsgPane {
   constructor(net, peerNick, onClose) {
     this.net = net;
@@ -19,14 +21,21 @@ export class PrivmsgPane {
       border-bottom:1px solid var(--border); background: var(--tab-bg);
       font-weight:600;
     `;
-    title.innerHTML = `<span style="flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">DM · ${this.peer}</span>`;
+    const titleSpan = el('span', {
+      text: `DM · ${this.peer}`,
+    });
+    titleSpan.style.flex = '1';
+    titleSpan.style.overflow = 'hidden';
+    titleSpan.style.textOverflow = 'ellipsis';
+    titleSpan.style.whiteSpace = 'nowrap';
+  
     const closeBtn = document.createElement('button');
     closeBtn.textContent = '×';
     closeBtn.title = 'Close';
     closeBtn.className = 'pill';
     closeBtn.style.padding = '2px 8px';
     closeBtn.addEventListener('click', () => onClose?.());
-    title.appendChild(closeBtn);
+    title.append(titleSpan, closeBtn);
 
     // transcript
     this.trans = document.createElement('div');


### PR DESCRIPTION
Fixes #4

This change hardens the renderer against XSS, cleans up noisy logs, and fixes a profile duplication bug (“Realname” vs “Real name”). It also simplifies DM user event handling and improves first-paint behavior in DM windows.

WHY
- Several UI surfaces constructed HTML via string concatenation and innerHTML. That made escaping uneven and brittle.
- DM header rendering could show both “Realname” and “Real name” when the backend provided `real_name` alongside normalized `realname`.
- The `DM_USER` flow was overly defensive/verbose; simplified logic is easier to reason about and maintain.
- DM windows needed immediate access to their session/peer identity.

WHAT
- Introduce a small, centralized DOM helper:
  - `renderer/lib/dom.js` with `el()` (textContent by default) to build DOM nodes safely. This becomes our preferred way to render UI instead of injecting HTML strings.

- Replace innerHTML with safe DOM building across the renderer:
  - `renderer/main.js`
    - Rework tab rendering to use `el()`, avoiding innerHTML.
  - `renderer/ui/ChannelListPane.js`
    - Build spinner, table head, and body via DOM nodes (no HTML strings).
  - `renderer/ui/ChannelPane.js`
    - Build users header and list container via DOM nodes safely.
  - `renderer/ui/PrivmsgPane.js`
    - Build the title bar (peer name + close button) using `el()`.
  - `renderer/ui/connectionForm.js`
    - Replace string-built labels with DOM nodes; no ad-hoc escaping.
    - Labels now compose from parts and are joined safely as text.

- DM window boot + user identity propagation:
  - `preload.cjs`
    - Track the current DM window identity: `currentDM = { sessionId, peer, selfNick }`.
    - Expose `api.dm.current` getter for the renderer to discover its state.
    - Wire `api.dm.pushUser(sessionId, user)` to main for multi-window DM updates.
    - On `dm:init`, persist `sessionId/peer` and immediately emit a minimal `DM_USER` so the header can paint right away.

- DM header rendering and duplication fix:
  - `renderer/dm.js`
    - On focus, proactively request a full profile snapshot and WHOIS when peer is known.
    - `renderProfile()` uses only text nodes, no HTML.
    - De-duplicate “Realname” vs “Real name” and “User” vs “Ident”:
      * Only show raw `real_name` or `ident` if they differ from normalized fields.
    - Keep header panel from appearing empty with a clear disabled placeholder.
    - Simplify `EVT.DM_USER` handler:
      * Adopt the first non-self nick as the peer.
      * Only render if the event matches the current peer (case-insensitive). * Ask for WHOIS only when absent (backend throttling/caching applies).

- Ingest simplification and targeted updates:
  - `renderer/irc/ingest.js`
    - Simplify `type:'user'` handling to a single-object path.
    - Merge onto existing user records by key (nick/username) to preserve prior fields.
    - Emit `EVT.DM_USER` and forward to `api.dm.pushUser` for DM windows.
    - Keep NickServ auto-identify logic and LIST numerics suppression intact.

SECURITY / RELIABILITY
- Removed unsafe `innerHTML` rendering in several views.
- Centralized safe DOM creation via `el()` (textContent-first).
- Reduced log verbosity and avoided spurious console noise in hot paths.
- Case-insensitive peer matching reduces header flapping/incorrect updates.

USER-FACING BEHAVIOR
- DM windows populate header info sooner (minimal stub, then full WHOIS).
- No duplicate “Realname”/“Real name” or “User”/“Ident” fields.
- Channel list/DM panes render identically but are safer and more stable.