### PR TITLE
#10 Explicit perf targets; batched transcript; capped chan list

### DIFF
--- a/docs/PERF.md
+++ b/docs/PERF.md
@@ -1,0 +1,14 @@
+# Performance Targets
+
+- Transcript panes:
+  - ≤ 2000 retained lines per pane (pruned in 200-line chunks).
+  - Coalesced appends (≤ 1 flush per animation frame).
+  - ≤ 200 appended lines processed per frame (backpressure guard).
+  - Auto-scroll only when within 40px of the bottom.
+
+- Channel list:
+  - Diff-only per-row updates on incremental changes.
+  - Snapshot renders collapsed to ≤ 1 per frame.
+  - Display cap: top 5000 rows by users (configurable).
+
+- Central config: see `renderer/config/perf.js`.

--- a/renderer/config/perf.js
+++ b/renderer/config/perf.js
@@ -1,0 +1,13 @@
+// renderer/config/perf.js
+export const PERF = Object.freeze({
+  // Transcript targets
+  TRANSCRIPT_MAX_LINES: 2000,
+  TRANSCRIPT_PRUNE_CHUNK: 200,
+  TRANSCRIPT_MAX_APPEND_PER_FRAME: 200, // backpressure guard
+  TRANSCRIPT_BATCH_MS: 16,              // coalesce bursts (1 frame)
+  TRANSCRIPT_SNAP_THRESHOLD_PX: 40,
+
+  // Channel list targets
+  CHANLIST_RENDER_CAP: 5000,     // show top N by users on snapshot
+  CHANLIST_RAF_RENDER: true,     // collapse multiple snapshot events into 1/raf
+});

--- a/renderer/ui/ChannelPane.js
+++ b/renderer/ui/ChannelPane.js
@@ -1,6 +1,7 @@
 import { Pane } from './base/Pane.js';
 import { Composer } from './widgets/Composer.js';
 import { TranscriptView } from './widgets/TranscriptView.js';
+import { PERF } from '../config/perf.js';
 import { el } from '../lib/dom.js';
 import { api } from '../lib/adapter.js';
 
@@ -12,7 +13,12 @@ export class ChannelPane extends Pane {
 
     this.root.classList.add('chan-pane', 'pane--with-composer');
 
-    this.view = new TranscriptView({ withTopic: true });
+    this.view = new TranscriptView({
+      withTopic: true,
+      maxLines: PERF.TRANSCRIPT_MAX_LINES,
+      pruneChunk: PERF.TRANSCRIPT_PRUNE_CHUNK,
+    });
+
     this.view.element.classList.add('transcript--with-divider');
 
     this.usersEl = el('div', { className: 'users' });

--- a/renderer/ui/ConsolePane.js
+++ b/renderer/ui/ConsolePane.js
@@ -1,6 +1,7 @@
 import { Pane } from './base/Pane.js';
 import { Composer } from './widgets/Composer.js';
 import { TranscriptView } from './widgets/TranscriptView.js';
+import { PERF } from '../config/perf.js';
 import { api } from '../lib/adapter.js';
 
 export class ConsolePane extends Pane {
@@ -9,7 +10,12 @@ export class ConsolePane extends Pane {
     this.net = net;
 
     // Structure: [Transcript] + [Composer]
-    this.view = new TranscriptView({ withTopic: false });
+    this.view = new TranscriptView({
+      withTopic: false,
+      maxLines: PERF.TRANSCRIPT_MAX_LINES,
+      pruneChunk: PERF.TRANSCRIPT_PRUNE_CHUNK,
+    });
+
     this.composer = new Composer({
       placeholder: 'Type a command or message...',
       onSubmit: (text) => {

--- a/renderer/ui/PrivmsgPane.js
+++ b/renderer/ui/PrivmsgPane.js
@@ -1,6 +1,7 @@
 import { Pane } from './base/Pane.js';
 import { Composer } from './widgets/Composer.js';
 import { TranscriptView } from './widgets/TranscriptView.js';
+import { PERF } from '../config/perf.js';
 import { api } from '../lib/adapter.js';
 
 export class PrivmsgPane extends Pane {
@@ -12,7 +13,12 @@ export class PrivmsgPane extends Pane {
 
     this.root.classList.add('console-pane');
 
-    this.view = new TranscriptView({ withTopic: false });
+    this.view = new TranscriptView({
+      withTopic: false,
+      maxLines: PERF.TRANSCRIPT_MAX_LINES,
+      pruneChunk: PERF.TRANSCRIPT_PRUNE_CHUNK,
+    });
+
     this.composer = new Composer({
       placeholder: `Message ${this.peer}`,
       onSubmit: (text) => {

--- a/renderer/ui/connectionForm.js
+++ b/renderer/ui/connectionForm.js
@@ -202,7 +202,7 @@ export function createProfilesPanel({ onConnect }) {
           </select>
         </div>
         <div class="form-row" id="eAuthUserRow" style="display:none;">
-          <label>Username</label><input id="eAuthUser" type="text" placeholder="SASL only — leave empty to inherit"/>
+          <label>Username</label><input id="eAuthUser" type="text" placeholder="SASL only - leave empty to inherit"/>
         </div>
         <div class="form-row" id="eAuthPassRow" style="display:none;">
           <label>Password</label><input id="eAuthPass" type="password" placeholder="leave empty to inherit"/>


### PR DESCRIPTION
## [Task](https://github.com/users/jesse-greathouse/projects/1/views/1?pane=issue&itemId=131015571&issue=jesse-greathouse%7Comni-chat%7C10)
- Issue: #10 
- Smell: Transcript joined into one node without batching; ChannelList re-renders wholesale; pruning relied on idle callbacks.
- Why it hurts: Fine for small sessions, but large nets/long sessions degrade and regressions are invisible.

What’s changed
• Centralized configuration
  - renderer/config/perf.js
    - TRANSCRIPT_MAX_LINES=2000
    - TRANSCRIPT_PRUNE_CHUNK=200
    - TRANSCRIPT_MAX_APPEND_PER_FRAME=200
    - TRANSCRIPT_SNAP_THRESHOLD_PX=40
    - CHANLIST_RENDER_CAP=5000
    - CHANLIST_RAF_RENDER=true
  - All panes consume PERF constants so targets are explicit and adjustable in one place.

• TranscriptView: coalesced appends + backpressure (smooth scrolling)
  - Batch appends per rAF with a per-frame cap (TRANSCRIPT_MAX_APPEND_PER_FRAME).
  - Maintain a small queue to drain bursts over multiple frames (keeps 60fps).
  - Respect reader position: only auto-scroll when within SNAP_THRESHOLD_PX of bottom.
  - Add CSS containment on the scroll node (`contain: content`) to reduce layout work.
  - Expose maxLines/pruneChunk via ctor options but default to PERF values.
  - Fix import path and internal plumbing for new config.

• Channel list: render less, render smarter
  - Collapse multiple CHAN_SNAPSHOT events to a single render per rAF (when enabled).
  - Cap snapshot paint to top CHANLIST_RENDER_CAP rows by user count.
  - Update info bar to show “Sorted by users (desc) — showing top N of M”.
  - Keep incremental CHAN_UPDATE path diff-based (no wholesale <tbody> rebuild on row change).

• Panes wired to PERF
  - ChannelPane / ConsolePane / PrivmsgPane now instantiate TranscriptView with PERF limits.

• Docs
  - docs/PERF.md describing targets, knobs, and rationale.

Small miscellaneous
  - Normalize a mojibake em-dash to a plain hyphen in connectionForm placeholder text.

Behavioral notes
- Transcript panes retain ~2k lines with chunked pruning; the UI only snaps to bottom when near it.
- Extremely bursty input drains progressively over multiple frames (no jank).
- Very large channel lists show the top N rows and surface that fact in the UI text.

Files
- docs/PERF.md
- renderer/config/perf.js
- renderer/ui/widgets/TranscriptView.js (batching, caps, contain, config)
- renderer/ui/ChannelListPane.js (rAF coalescing, cap, info text)
- renderer/ui/ChannelPane.js (use PERF)
- renderer/ui/ConsolePane.js (use PERF)
- renderer/ui/PrivmsgPane.js (use PERF)
- renderer/ui/connectionForm.js (text placeholder dash normalization)

Closes #10.