### PR TITLE
#31 Bond live UI values to the cached config object instead of config defaults

### DIFF
--- a/renderer/config/baseline.js
+++ b/renderer/config/baseline.js
@@ -5,7 +5,7 @@ import { DEFAULTS } from './defaults.js';
 export const SHEET = Object.freeze({
   // UI -----------------------------------------------------------------------
   ui: {
-    footerGap: 6,
+    footerGap: '6px',
   },
 
   // Performance ---------------------------------------------------------------

--- a/renderer/styles/components.css
+++ b/renderer/styles/components.css
@@ -117,9 +117,10 @@ select option { background: var(--surface); color: var(--fg); }
 .topic { margin: 0 0 var(--space-8) 0; font-size: 12px; color: var(--muted); }
 
 /* transcript base (shared) */
+/* base */
 .transcript {
-  position:relative;
-  min-height:0;
+  position: relative;
+  min-height: 0;
   padding-block: var(--pad-y);
   padding-inline: var(--pad-x);
   overflow: auto;
@@ -128,7 +129,12 @@ select option { background: var(--surface); color: var(--fg); }
   font-family: var(--font-mono);
   background: var(--transcript-bg);
 }
-.with-footer-gap { padding-bottom: calc(var(--footer-h) + var(--footer-gap)); }
+
+/* footer-aware variant */
+.transcript.with-footer-gap {
+  /* use logical end padding; include fallbacks so UI updates never collapse */
+  padding-block-end: calc(var(--footer-h, 40px) + var(--footer-gap, 6px));
+}
 
 /* bordered surface helper */
 .panel {


### PR DESCRIPTION
## Summary

Wire the UI and performance knobs to the live config bus so changes apply immediately without reload, and harden the footer gap CSS variable to prevent `NaNpx` footguns. Also keep inherited connection fields bonded to global settings.

## Key changes

* **UI footer gap**

  * Change default in `SHEET.ui.footerGap` from `6` → `'6px'`.
  * Add `normalizePx()` in `TranscriptView` and set `--footer-gap` safely (accepts `6`, `'6'`, `'6px'`; falls back to `SHEET.ui.footerGap`).
  * Listen for `settings:changed` (`ui.footerGap`) and update CSS var live.
  * CSS: switch `.with-footer-gap` to `.transcript.with-footer-gap` and use `padding-block-end: calc(var(--footer-h, 40px) + var(--footer-gap, 6px))` with sensible fallbacks.

* **Transcript performance (live)**

  * `TranscriptView` now tracks perf values on the instance and updates them on `settings:changed` (`perf` domain):

    * `TRANSCRIPT_MAX_LINES`
    * `TRANSCRIPT_PRUNE_CHUNK`
    * `TRANSCRIPT_SNAP_THRESHOLD_PX`
    * `TRANSCRIPT_MAX_APPEND_PER_FRAME`
  * Replace inline `PERF.*` reads during append/RAF loops with the live instance fields.
  * Keep code magic-string free by falling back to `SHEET.perf` values.

* **Channel list performance (live)**

  * `ChannelListPane` now reads `CHANLIST_RAF_RENDER` and `CHANLIST_RENDER_CAP` into a local `_perf` bag and updates them on `settings:changed (perf)`.
  * Render path chooses RAF vs immediate based on live toggle; render cap updates trigger a re-render to apply immediately.

* **Connection globals bonding**

  * In `store.ensureNetwork()`, detect which fields are inherited vs explicit and seed from `CONNECT.globals` when appropriate.
  * Subscribe to `settings:changed (globals)` and update only the inherited fields in existing network structs live (`nick`, `realname`, `authType`, `authUsername`, `authPassword`).

## Files

* `renderer/config/baseline.js`

  * `footerGap: '6px'` (default string unit).
* `renderer/state/store.js`

  * Bond inherited connection fields to `CONNECT.globals` and live-update on `settings:changed`.
* `renderer/styles/components.css`

  * Normalize transcript base rules; add `.transcript.with-footer-gap` with `padding-block-end` and CSS var fallbacks.
* `renderer/ui/ChannelListPane.js`

  * Live `_perf` bag; subscribe to `perf` updates; use live values in snapshot rendering path.
* `renderer/ui/widgets/TranscriptView.js`

  * Add `normalizePx()`, import `UI`, `SHEET`, `api`.
  * Keep transcript perf knobs on instance; subscribe to `ui` and `perf` changes; use live fields in RAF loops.

## Rationale

* Removes dependence on static `PERF` reads during construction so tuning can be done at runtime.
* Prevents invalid CSS such as `--footer-gap: NaNpx` when the cache returns unexpected shapes.
* Keeps defaults centralized and non-magical by falling back to `SHEET` when live values are absent.

## Testing notes

* Verified changing `ui.footerGap` live updates padding and avoids `NaNpx` (accepts `6`, `'6'`, `'6px'`).
* Verified toggling `perf.CHANLIST_RAF_RENDER` switches between RAF and immediate render without reload.
* Verified changing `perf.CHANLIST_RENDER_CAP` applies immediately to the visible list.
* Verified changing transcript perf values (`MAX_LINES`, `PRUNE_CHUNK`, `SNAP_THRESHOLD_PX`, `MAX_APPEND_PER_FRAME`) takes effect while appending.
* Verified updating `globals` mutates only inherited fields on existing networks.

## Follow-ups (out of scope here)

* Input validation & user feedback in settings UI.
* Save-on-change (remove explicit “Save” buttons).
* Consider wiring `TRANSCRIPT_BATCH_MS` to an optional time-based throttle if needed.

---